### PR TITLE
Add NeoVim support and extra functionalities

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,72 +14,72 @@ to the connection, with responses echo'd in a separate window.
 ## How?
 
 First, install with your favorite method. You'll also need [wildwildws-d][2],
-which is available via npm. I like [vim-plug][3], which can do both:
+    which is available via npm. I like [vim-plug][3], which can do both:
 
-```vim
-Plug 'dhleong/vim-wildwildws', {'do': 'npm i -g wildwildws-d'}
-```
+    ```vim
+    Plug 'dhleong/vim-wildwildws', {'do': 'npm i -g wildwildws-d'}
+    ```
 
-Once installed, you can either create a file that ends in `.wwws`, or pass an
-url to the `:WWWS` command, which will do a tiny bit of setup for you:
+    Once installed, you can either create a file that ends in `.wwws`, or pass an
+    url to the `:WWWS` command, which will do a tiny bit of setup for you:
 
-```vim
-:WWWS ws://demos.kaazing.com/echo
-```
+    ```vim
+    :WWWS ws://demos.kaazing.com/echo
+    ```
 
-Either way, your `.wwws` file needs to contain a line that looks like this:
+    Either way, your `.wwws` file needs to contain a line that looks like this:
 
-```javascript
-URI: ws://demos.kaazing.com/echo
-```
+    ```javascript
+    URI: ws://demos.kaazing.com/echo
+    ```
 
-This tells wildwildws where to connect. With this in your file, wildwildws by
-default will automatically connect for you when you save the file.
+    This tells wildwildws where to connect. With this in your file, wildwildws by
+    default will automatically connect for you when you save the file.
 
-Once connected, simply press the enter key in normal mode to send the
-paragraph under the cursor to the connection. Easy!
+    Once connected, simply press the enter key in normal mode to send the
+    paragraph under the cursor to the connection. Easy!
 
-Output from the server is printed in a separate buffer that is opened for you.
-It's a normal buffer, so you can navigate to it and manipulate its text in all
-the normal Vim ways.
+    Output from the server is printed in a separate buffer that is opened for you.
+    It's a normal buffer, so you can navigate to it and manipulate its text in all
+    the normal Vim ways.
 
-wildwildws will automatically dispose the output window when you close the
-`.wwws` buffer, and will also disconnect for you. If you need to disconnect
-sooner, a `:Disconnect` command is provided.
+    wildwildws will automatically dispose the output window when you close the
+    `.wwws` buffer, and will also disconnect for you. If you need to disconnect
+    sooner, a `:Disconnect` command is provided.
 
 ### Headers
 
-If you need to send headers along with your initial HTTP request, you can
-just put them on their own lines, much like the `URI:` directive. For example:
+    If you need to send headers along with your initial HTTP request, you can
+    just put them on their own lines, much like the `URI:` directive. For example:
 
-```javascript
-URI: ws://localhost:3000/api/ws
-Authorization: Token {"username":"Bar"}
-X-Format: compressed
-```
+    ```javascript
+    URI: ws://localhost:3000/api/ws
+    Authorization: Token {"username":"Bar"}
+    X-Format: compressed
+    ```
 
-will send the `Authorization` and `X-Format` headers. Also easy!
+    will send the `Authorization` and `X-Format` headers. Also easy!
 
 ### Commands
 
-`:Send` will send all the arguments as-is to the server as text.
+    `:Send` will send all the arguments as-is to the server as text.
 
-`:Disconnect`
-`:Connect` both do what you'd expect.
+    `:Disconnect`
+    `:Connect` both do what you'd expect.
 
 ### Options
 
-See [this file][4] for all the options with explanations. Help files to
-come... eventually.
+    See [this file][4] for all the options with explanations. Help files to
+    come... eventually.
 
 ### Functions
 
-If you want to write your own mappings, `wwws#conn#Open()` and
-`wwws#conn#Close()` open and close the connection for the current `.wwws`
-buffer, respectively. `wwws#conn#Send()` accepts a single string and sends it
-directly.
+    If you want to write your own mappings, `wwws#conn#Open()` and
+    `wwws#conn#Close()` open and close the connection for the current `.wwws`
+    buffer, respectively. `wwws#conn#Send()` accepts a single string and sends it
+    directly.
 
-[1]: https://github.com/baverman/vial-http
-[2]: https://github.com/dhleong/wildwildws-d
-[3]: https://github.com/junegunn/vim-plug
-[4]: https://github.com/dhleong/vim-wildwildws/blob/master/plugin/wwws.vim
+    [1]: https://github.com/baverman/vial-http
+    [2]: https://github.com/dhleong/wildwildws-d
+    [3]: https://github.com/junegunn/vim-plug
+    [4]: https://github.com/dhleong/vim-wildwildws/blob/master/plugin/wwws.vim

--- a/autoload/wwws.vim
+++ b/autoload/wwws.vim
@@ -32,6 +32,7 @@ func! wwws#OpenNew(...)
 	exe openMethod . ' ' . name . '.wwws'
 
 	call append(0, 'URI: ' . uri)
+	let b:_headersSize = 1
 
 	set nomodified
 
@@ -63,6 +64,7 @@ func! wwws#_getParams() " {{{
 			let params['uri'] = s:formatUri(value)
 		else
 			let headers[name] = value
+			b:_headersSize = b:_headersSize + 1
 		endif
 	endfor
 

--- a/autoload/wwws.vim
+++ b/autoload/wwws.vim
@@ -1,70 +1,70 @@
 func! s:formatUri(uri)
-    let uri = a:uri
+	let uri = a:uri
 
-    if matchstr(uri, '^.*://') ==# ''
-        " no protocol? assume non-secure
-        let uri = 'ws://' . uri
-    endif
+	if matchstr(uri, '^.*://') ==# ''
+		" no protocol? assume non-secure
+		let uri = 'ws://' . uri
+	endif
 
-    return uri
+	return uri
 endfunc
 
 func! wwws#OpenNew(...)
 
-    let openMethod = 'tabedit'
-    if bufname(bufnr('%')) ==# ''
-        " editing a file? prefer tabe
-        let openMethod = 'edit'
-    endif
+	let openMethod = 'tabedit'
+	if bufname(bufnr('%')) ==# ''
+		" editing a file? prefer tabe
+		let openMethod = 'edit'
+	endif
 
-    let uri = ''
-    if a:0 == 0
-        echom 'You must at least provide a ws:// or wss:// URI'
-        return
-    elseif a:0 == 1
-        let uri = a:1
-    elseif a:0 == 2
-        let openMethod = a:1
-        let uri = a:2
-    endif
+	let uri = ''
+	if a:0 == 0
+		echom 'You must at least provide a ws:// or wss:// URI'
+		return
+	elseif a:0 == 1
+		let uri = a:1
+	elseif a:0 == 2
+		let openMethod = a:1
+		let uri = a:2
+	endif
 
-    let name = wwws#util#safename(uri)
-    exe openMethod . ' ' . name . '.wwws'
+	let name = wwws#util#safename(uri)
+	exe openMethod . ' ' . name . '.wwws'
 
-    call append(0, 'URI: ' . uri)
+	call append(0, 'URI: ' . uri)
 
-    set nomodified
+	set nomodified
 
-    if g:wwws_auto_connect
-        " the ftplugin also does this, but that gets called before we
-        " get a chance to insert the URI, so let's try now
-        call wwws#conn#Open()
-    endif
+	if g:wwws_auto_connect
+		" the ftplugin also does this, but that gets called before we
+		" get a chance to insert the URI, so let's try now
+		call wwws#conn#Open()
+	endif
 endfunc
 
 func! wwws#_getParams() " {{{
-    let headers = {}
-    let params = {
-        \ 'uri': '',
-        \ 'headers': headers,
-        \ }
+	let headers = {}
+	let params = {
+				\ 'uri': '',
+				\ 'headers': headers,
+				\ }
 
-    let lines = getline(1, '$')
-    for line in lines
-        let matches = matchlist(line, '^\([a-z-A-Z0-9-_]\+\):[ ]*\(.\+\)$')
-        if len(matches) == 0
-            continue
-        endif
+	let lines = getline(1, '$')
+	for line in lines
+		let matches = matchlist(line, '^\([a-z-A-Z0-9-_]\+\):[ ]*\(.\+\)$')
+		if len(matches) == 0
+			continue
+		endif
 
-        let name = matches[1]
-        let value = matches[2]
+		let name = matches[1]
+		let value = matches[2]
 
-        if name ==# 'URI'
-            let params['uri'] = s:formatUri(value)
-        else
-            let headers[name] = value
-        endif
-    endfor
+		if name ==# 'URI'
+			let params['uri'] = s:formatUri(value)
+		else
+			let headers[name] = value
+		endif
+	endfor
 
-    return params
+	return params
 endfunc " }}} 

--- a/autoload/wwws/buffer.vim
+++ b/autoload/wwws/buffer.vim
@@ -1,5 +1,4 @@
-
-func! wwws#buffer#SendParagraph()
+func! wwws#buffer#_SendWrapper(motion)
 	let reg = '"'
 
 	let cursor = getcurpos()
@@ -11,7 +10,7 @@ func! wwws#buffer#SendParagraph()
 	let reg_type = getregtype(reg)
 
 	" select the paragraph and get its text
-	silent exe 'normal! "' . reg . 'GVggy'
+	silent exe 'normal! "' . reg . a:motion
 	let toSend = getreg(reg)
 
 	" restore settings
@@ -23,3 +22,24 @@ func! wwws#buffer#SendParagraph()
 	" send the value
 	call wwws#conn#Send(toSend)
 endfunc
+
+func! wwws#buffer#SendParagraph()
+	call wwws#buffer#_SendWrapper('GVggy')
+endfunc
+
+func! wwws#buffer#SendLine()
+	call wwws#buffer#_SendWrapper('yy')
+endfunc
+
+func! wwws#buffer#SendDeleteParagraph()
+	call wwws#buffer#_SendWrapper('GVggd')
+endfunc
+
+func! wwws#buffer#SendHeadless()
+	call wwws#buffer#_SendWrapper('GVgg' . b:_headersSize . 'jy')
+endfunc
+
+func! wwws#buffer#SendDeleteHeadless()
+	call wwws#buffer#_SendWrapper('GVgg' . b:_headersSize . 'jd')
+endfunc
+

--- a/autoload/wwws/buffer.vim
+++ b/autoload/wwws/buffer.vim
@@ -1,25 +1,25 @@
 
 func! wwws#buffer#SendParagraph()
-    let reg = '"'
+	let reg = '"'
 
-    let cursor = getcurpos()
-    let sel_save = &selection
-    let &selection = 'inclusive'
-    let cb_save  = &clipboard
-    set clipboard-=unnamed clipboard-=unnamedplus
-    let reg_save = getreg(reg)
-    let reg_type = getregtype(reg)
+	let cursor = getcurpos()
+	let sel_save = &selection
+	let &selection = 'inclusive'
+	let cb_save  = &clipboard
+	set clipboard-=unnamed clipboard-=unnamedplus
+	let reg_save = getreg(reg)
+	let reg_type = getregtype(reg)
 
-    " select the paragraph and get its text
-    silent exe 'normal! "' . reg . 'GVggy'
-    let toSend = getreg(reg)
+	" select the paragraph and get its text
+	silent exe 'normal! "' . reg . 'GVggy'
+	let toSend = getreg(reg)
 
-    " restore settings
-    call setreg(reg, reg_save, reg_type)
-    let &clipboard = cb_save
-    let &selection = sel_save
-    call setpos('.', cursor)
+	" restore settings
+	call setreg(reg, reg_save, reg_type)
+	let &clipboard = cb_save
+	let &selection = sel_save
+	call setpos('.', cursor)
 
-    " send the value
-    call wwws#conn#Send(toSend)
+	" send the value
+	call wwws#conn#Send(toSend)
 endfunc

--- a/autoload/wwws/buffer.vim
+++ b/autoload/wwws/buffer.vim
@@ -11,7 +11,7 @@ func! wwws#buffer#SendParagraph()
     let reg_type = getregtype(reg)
 
     " select the paragraph and get its text
-    silent exe 'normal! "' . reg . 'yap'
+    silent exe 'normal! "' . reg . 'GVggy'
     let toSend = getreg(reg)
 
     " restore settings

--- a/autoload/wwws/conn.vim
+++ b/autoload/wwws/conn.vim
@@ -1,160 +1,160 @@
 
 func! s:intowin(kind)
-    let bufnr = b:_wwws[a:kind . '_bufnr']
-    let winnr = bufwinnr(bufnr)
-    if winnr == -1
-        " no such window
-        return 0
-    endif
+	let bufnr = b:_wwws[a:kind . '_bufnr']
+	let winnr = bufwinnr(bufnr)
+	if winnr == -1
+		" no such window
+		return 0
+	endif
 
-    exec winnr . 'wincmd w'
-    return 1
+	exec winnr . 'wincmd w'
+	return 1
 endfunc
 
 func! s:appendOutput(lines)
-    if s:intowin('output')
-        set modifiable
-        call append(line('$'), a:lines)
-        call s:intowin('input')
-    endif
+	if s:intowin('output')
+		set modifiable
+		call append(line('$'), a:lines)
+		call s:intowin('input')
+	endif
 endfunc
 
 func! s:isReady()
-    return !empty(get(b:, '_wwws', {}))
+	return !empty(get(b:, '_wwws', {}))
 endfunc
 
 func! wwws#conn#Open() " {{{
-    call wwws#output#EnsureAvailable()
+	call wwws#output#EnsureAvailable()
 
-    if !s:isReady()
-        return
-    endif
+	if !s:isReady()
+		return
+	endif
 
-    if type(get(b:_wwws, 'job', 'no job')) == (has('nvim') ? v:t_number : v:t_job)
-        echo 'Already connected'
-        return
-    endif
+	if type(get(b:_wwws, 'job', 'no job')) == (has('nvim') ? v:t_number : v:t_job)
+		echo 'Already connected'
+		return
+	endif
 
-    " gather connection params
-    let params = wwws#_getParams()
-    if get(params, 'uri', '') ==# ''
-        return
-    endif
+	" gather connection params
+	let params = wwws#_getParams()
+	if get(params, 'uri', '') ==# ''
+		return
+	endif
 
-    let outputBufNr = b:_wwws['output_bufnr']
-    call s:intowin('output')
-    norm! ggdG
-    call s:intowin('input')
+	let outputBufNr = b:_wwws['output_bufnr']
+	call s:intowin('output')
+	norm! ggdG
+	call s:intowin('input')
 
-    let cmd = ['wildwildws-d', params['uri']]
+	let cmd = ['wildwildws-d', params['uri']]
 
-    for [key, value] in items(params['headers'])
-        let cmd = cmd + ['-h', key . ':' . value]
-    endfor
+	for [key, value] in items(params['headers'])
+		let cmd = cmd + ['-h', key . ':' . value]
+	endfor
 
-    func! OnOutput(channel, msg) closure
-        " TODO parse anything?
-    endfunc
+	func! OnOutput(channel, msg) closure
+		" TODO parse anything?
+	endfunc
 
-    func! OnExit(channel, exitCode) closure
-        call wwws#conn#Close()
-    endfunc
+	func! OnExit(channel, exitCode) closure
+		call wwws#conn#Close()
+	endfunc
 
-    let args = {
-        \ 'out_mode': 'nl',
-        \ 'out_modifiable': 0,
-        \ 'out_io': 'buffer',
-        \ 'out_buf': outputBufNr,
-        \ 'err_modifiable': 0,
-        \ 'err_io': 'buffer',
-        \ 'err_buf': outputBufNr,
-        \ 'out_cb': 'OnOutput',
-        \ 'exit_cb': 'OnExit',
-        \ }
-    let job = (has('nvim') ? jobstart(cmd, args) : job_start(cmd, args))
-    let b:_wwws['job'] = job
+	let args = {
+				\ 'out_mode': 'nl',
+				\ 'out_modifiable': 0,
+				\ 'out_io': 'buffer',
+				\ 'out_buf': outputBufNr,
+				\ 'err_modifiable': 0,
+				\ 'err_io': 'buffer',
+				\ 'err_buf': outputBufNr,
+				\ 'out_cb': 'OnOutput',
+				\ 'exit_cb': 'OnExit',
+				\ }
+	let job = (has('nvim') ? jobstart(cmd, args) : job_start(cmd, args))
+	let b:_wwws['job'] = job
 endfunc " }}}
 
 func! wwws#conn#CloseFor(inputBufNr)
-    " disconnect; leave the output buffer open
-    let _wwws = getbufvar(a:inputBufNr, '_wwws', {})
-    let job = get(_wwws, 'job', 'no job')
-    if type(job) != (has('nvim') ? v:t_number : v:t_job)
-        return
-    endif
+	" disconnect; leave the output buffer open
+	let _wwws = getbufvar(a:inputBufNr, '_wwws', {})
+	let job = get(_wwws, 'job', 'no job')
+	if type(job) != (has('nvim') ? v:t_number : v:t_job)
+		return
+	endif
 
-    if has('nvim')
-	call jobstop(job)
-    else
-	call job_stop(job)
-    endif
-    unlet _wwws['job']
+	if has('nvim')
+		call jobstop(job)
+	else
+		call job_stop(job)
+	endif
+	unlet _wwws['job']
 endfunc
 
 func! wwws#conn#Close() " {{{
-    if !s:isReady()
-        " nothing to do
-        return
-    endif
+	if !s:isReady()
+		" nothing to do
+		return
+	endif
 
-    call wwws#conn#CloseFor(bufnr('%'))
+	call wwws#conn#CloseFor(bufnr('%'))
 
-    call s:appendOutput(['', '// Disconnected'])
+	call s:appendOutput(['', '// Disconnected'])
 endfunc " }}}
 
 func! wwws#conn#Send(message) " {{{
-    " always try to reconnect if disconnected when sending
-    call wwws#conn#TryConnect()
+	" always try to reconnect if disconnected when sending
+	call wwws#conn#TryConnect()
 
-    let job = get(b:_wwws, 'job', 'no job')
-    if type(job) != (has('nvim') ? v:t_number : v:t_job)
-        echo 'Not connected'
-        return
-    endif
+	let job = get(b:_wwws, 'job', 'no job')
+	if type(job) != (has('nvim') ? v:t_number : v:t_job)
+		echo 'Not connected'
+		return
+	endif
 
-    if has('nvim')
-	call chansend(job, [ a:message, "\n" ])
-    else
-	call ch_sendraw(job, a:message . "\n")
-    endif
+	if has('nvim')
+		call chansend(job, [ a:message, "\n" ])
+	else
+		call ch_sendraw(job, a:message . "\n")
+	endif
 endfunc " }}}
 
 func! wwws#conn#TryConnect() " {{{
-    if !g:wwws_connect_on_save
-        return
-    endif
+	if !g:wwws_connect_on_save
+		return
+	endif
 
-    call wwws#output#EnsureAvailable()
-    if !s:isReady()
-        return
-    endif
+	call wwws#output#EnsureAvailable()
+	if !s:isReady()
+		return
+	endif
 
-    if type(get(b:_wwws, 'job', 'no job')) == (has('nvim') ? v:t_number : v:t_job)
-        " already connected
-        return
-    endif
+	if type(get(b:_wwws, 'job', 'no job')) == (has('nvim') ? v:t_number : v:t_job)
+		" already connected
+		return
+	endif
 
-    call wwws#conn#Open()
+	call wwws#conn#Open()
 endfunc " }}}
 
 func! wwws#conn#_closed() " {{{
-    call wwws#conn#Close()
+	call wwws#conn#Close()
 
-    let b:wwws_init = 0
+	let b:wwws_init = 0
 
-    if !has_key(b:, '_wwws')
-        " not prepped yet
-        return
-    endif
+	if !has_key(b:, '_wwws')
+		" not prepped yet
+		return
+	endif
 
-    let outputBufNr = b:_wwws['output_bufnr']
-    if bufname(outputBufNr) !=# ''
-        try
-            exec 'bwipeout ' . outputBufNr
-        catch /.*/
-            " on an error, the output buffer doesn't exist anymore
-        endtry
-    endif
+	let outputBufNr = b:_wwws['output_bufnr']
+	if bufname(outputBufNr) !=# ''
+		try
+			exec 'bwipeout ' . outputBufNr
+		catch /.*/
+			" on an error, the output buffer doesn't exist anymore
+		endtry
+	endif
 endfunc " }}}
 
 

--- a/autoload/wwws/conn.vim
+++ b/autoload/wwws/conn.vim
@@ -27,11 +27,11 @@ func! wwws#conn#Open() " {{{
     call wwws#output#EnsureAvailable()
 
     if !s:isReady()
-        " not ready yet
+        echo 'Not ready yet'
         return
     endif
 
-    if type(get(b:_wwws, 'job', 0)) == v:t_job
+    if type(get(b:_wwws, 'job', 'no job')) == v:t_number
         echo 'Already connected'
         return
     endif
@@ -61,7 +61,7 @@ func! wwws#conn#Open() " {{{
         call wwws#conn#Close()
     endfunc
 
-    let job = job_start(cmd, {
+    let job = jobstart(cmd, {
         \ 'out_mode': 'nl',
         \ 'out_modifiable': 0,
         \ 'out_io': 'buffer',
@@ -78,12 +78,12 @@ endfunc " }}}
 func! wwws#conn#CloseFor(inputBufNr)
     " disconnect; leave the output buffer open
     let _wwws = getbufvar(a:inputBufNr, '_wwws', {})
-    let job = get(_wwws, 'job', 0)
-    if type(job) != v:t_job
+    let job = get(_wwws, 'job', 'no job')
+    if type(job) != v:t_number
         return
     endif
 
-    call job_stop(job)
+    call jobstop(job)
     unlet _wwws['job']
 endfunc
 
@@ -102,13 +102,13 @@ func! wwws#conn#Send(message) " {{{
     " always try to reconnect if disconnected when sending
     call wwws#conn#TryConnect()
 
-    let job = get(b:_wwws, 'job', 0)
-    if type(job) != v:t_job
+    let job = get(b:_wwws, 'job', 'no job')
+    if type(job) != v:t_number
         echo 'Not connected'
         return
     endif
 
-    call ch_sendraw(job, a:message . "\n")
+    call chansend(job, [ a:message, "\n" ])
 endfunc " }}}
 
 func! wwws#conn#TryConnect() " {{{
@@ -121,7 +121,7 @@ func! wwws#conn#TryConnect() " {{{
         return
     endif
 
-    if type(get(b:_wwws, 'job', 0)) == v:t_job
+    if type(get(b:_wwws, 'job', 'no job')) == v:t_number
         " already connected
         return
     endif
@@ -148,4 +148,5 @@ func! wwws#conn#_closed() " {{{
         endtry
     endif
 endfunc " }}}
+
 

--- a/autoload/wwws/conn.vim
+++ b/autoload/wwws/conn.vim
@@ -73,6 +73,7 @@ func! wwws#conn#Open() " {{{
 				\ }
 	let job = (has('nvim') ? jobstart(cmd, args) : job_start(cmd, args))
 	let b:_wwws['job'] = job
+	call s:appendOutput(['', '// Connected'])
 endfunc " }}}
 
 func! wwws#conn#CloseFor(inputBufNr)
@@ -113,7 +114,7 @@ func! wwws#conn#Send(message) " {{{
 	endif
 
 	if has('nvim')
-		call chansend(job, [ a:message, "\n" ])
+		call chansend(job, split(a:message, '\n'))
 	else
 		call ch_sendraw(job, a:message . "\n")
 	endif

--- a/autoload/wwws/output.vim
+++ b/autoload/wwws/output.vim
@@ -1,59 +1,59 @@
 " Output buffer/window management
 
 func! s:disconnectFrom(inputBufNr)
-    call wwws#conn#CloseFor(a:inputBufNr)
+	call wwws#conn#CloseFor(a:inputBufNr)
 endfunc
 
 func! wwws#output#EnsureAvailable()
-    let params = wwws#_getParams()
-    if get(params, 'uri', '') ==# ''
-        " nothing to do yet
-        return
-    endif
+	let params = wwws#_getParams()
+	if get(params, 'uri', '') ==# ''
+		" nothing to do yet
+		return
+	endif
 
-    let protocol = matchstr(params['uri'], 'w[s]*')
-    let bufname = bufname('%') . ': '
-        \ . protocol . '://'
-        \ . wwws#util#safename(params['uri'])
-    let bufnr = bufnr('%')
+	let protocol = matchstr(params['uri'], 'w[s]*')
+	let bufname = bufname('%') . ': '
+				\ . protocol . '://'
+				\ . wwws#util#safename(params['uri'])
+	let bufnr = bufnr('%')
 
-    let existing = bufnr(bufname)
-    if existing != -1
-        if !has_key(b:, '_wwws')
-            let b:_wwws = {}
-        endif
-        let b:_wwws.input_bufnr = bufnr
-        let b:_wwws.output_bufnr = existing
-        return
-    endif
+	let existing = bufnr(bufname)
+	if existing != -1
+		if !has_key(b:, '_wwws')
+			let b:_wwws = {}
+		endif
+		let b:_wwws.input_bufnr = bufnr
+		let b:_wwws.output_bufnr = existing
+		return
+	endif
 
-    exe 'silent keepalt below split ' . bufname
-    let outputBuf = bufnr('%')
-    let b:_wwws = {
-        \ 'input_bufnr': bufnr,
-        \ 'output_bufnr': outputBuf,
-        \ }
-    setlocal nomodifiable
-    setlocal nomodified
-    setlocal nolist
-    setlocal noswapfile
-    setlocal nobuflisted
-    setlocal buftype=nofile
-    setlocal bufhidden=wipe
-    set filetype=javascript
+	exe 'silent keepalt below split ' . bufname
+	let outputBuf = bufnr('%')
+	let b:_wwws = {
+				\ 'input_bufnr': bufnr,
+				\ 'output_bufnr': outputBuf,
+				\ }
+	setlocal nomodifiable
+	setlocal nomodified
+	setlocal nolist
+	setlocal noswapfile
+	setlocal nobuflisted
+	setlocal buftype=nofile
+	setlocal bufhidden=wipe
+	set filetype=javascript
 
-    " disable linting in the output window
-    let b:ale_enabled = 0
+	" disable linting in the output window
+	let b:ale_enabled = 0
 
-    augroup WwwsOutput
-        autocmd! * <buffer>
-        exe 'autocmd BufWipeout <buffer> call <SID>disconnectFrom(' . bufnr . ')'
-    augroup END
+	augroup WwwsOutput
+		autocmd! * <buffer>
+		exe 'autocmd BufWipeout <buffer> call <SID>disconnectFrom(' . bufnr . ')'
+	augroup END
 
-    " return to the input window
-    exe bufwinnr(bufnr) . 'wincmd w'
-    let b:_wwws = {
-        \ 'input_bufnr': bufnr,
-        \ 'output_bufnr': outputBuf,
-        \ }
+	" return to the input window
+	exe bufwinnr(bufnr) . 'wincmd w'
+	let b:_wwws = {
+				\ 'input_bufnr': bufnr,
+				\ 'output_bufnr': outputBuf,
+				\ }
 endfunc

--- a/autoload/wwws/util.vim
+++ b/autoload/wwws/util.vim
@@ -1,7 +1,7 @@
 
 func! wwws#util#safename(uri)
-    let name = substitute(a:uri, 'w[s]*://', '', 0)
-    let name = substitute(name, '[\/:]', '-', 'g')
-    return name
+	let name = substitute(a:uri, 'w[s]*://', '', 0)
+	let name = substitute(name, '[\/:]', '-', 'g')
+	return name
 endfunc
 

--- a/ftplugin/wwws.vim
+++ b/ftplugin/wwws.vim
@@ -17,6 +17,11 @@ let b:wwws_init = 1
 command! -buffer -nargs=0 Connect :call wwws#conn#Open()
 command! -buffer -nargs=0 Disconnect :call wwws#conn#Close()
 command! -buffer -nargs=+ Send :call wwws#conn#Send(<q-args>)
+command! -buffer -nargs=0 SendLine :call wwws#buffer#SendLine()
+command! -buffer -nargs=0 SendDeleteParagraph :call wwws#buffer#SendDeleteParagraph()
+command! -buffer -nargs=0 SendHeadless :call wwws#buffer#SendHeadless()
+command! -buffer -nargs=0 SendDeleteHeadless :call wwws#buffer#SendDeleteHeadless()
+command! -buffer -nargs=0 TryConnect :call wwws#conn#TryConnect()
 
 
 " ======= Output window prep ===============================
@@ -37,6 +42,11 @@ if g:wwws_auto_connect
 endif
 
 if g:wwws_create_maps
-	nnoremap <buffer> <cr> :call wwws#buffer#SendParagraph()<cr>
-	nnoremap <buffer> <del> :call wwws#buffer#Close()<del>
+	nnoremap <buffer> <CR> :call wwws#buffer#SendParagraph()<CR>
+	nnoremap <buffer> <C-CR> :call wwws#buffer#SendLine()<CR>
+	nnoremap <buffer> <ESC> :call wwws#conn#Close()<CR>
+	nnoremap <buffer> <C-R> :call wwws#conn#TryConnect()<CR>
+	nnoremap <buffer> <del> :call wwws#buffer#SendDeleteParagraph()<CR>
+	nnoremap <buffer> <C-S-H> :call wwws#buffer#SendHeadless()<CR>
+	nnoremap <buffer> <C-S-BS> :call wwws#buffer#SendDeleteHeadless()<CR>
 endif

--- a/ftplugin/wwws.vim
+++ b/ftplugin/wwws.vim
@@ -2,13 +2,13 @@
 " Only init once
 if get(b:, 'wwws_init', 0)
 
-    " but if we re-open with :e, for example, we might
-    " want to try to reconnect
-    if g:wwws_auto_connect
-        call wwws#conn#TryConnect()
-    endif
+	" but if we re-open with :e, for example, we might
+	" want to try to reconnect
+	if g:wwws_auto_connect
+		call wwws#conn#TryConnect()
+	endif
 
-    finish
+	finish
 endif
 let b:wwws_init = 1
 
@@ -26,17 +26,17 @@ call wwws#output#EnsureAvailable()
 " ======= Final wwws buffer configs ========================
 
 augroup WWWS
-    autocmd! * <buffer>
-    autocmd BufHidden <buffer> :call wwws#conn#_closed()
-    autocmd BufDelete <buffer> :call wwws#conn#_closed()
-    autocmd BufWritePost <buffer> :call wwws#conn#TryConnect()
+	autocmd! * <buffer>
+	autocmd BufHidden <buffer> :call wwws#conn#_closed()
+	autocmd BufDelete <buffer> :call wwws#conn#_closed()
+	autocmd BufWritePost <buffer> :call wwws#conn#TryConnect()
 augroup END
 
 if g:wwws_auto_connect
-    call wwws#conn#Open()
+	call wwws#conn#Open()
 endif
 
 if g:wwws_create_maps
-    nnoremap <buffer> <cr> :call wwws#buffer#SendParagraph()<cr>
-    nnoremap <buffer> <del> :call wwws#buffer#Close()<del>
+	nnoremap <buffer> <cr> :call wwws#buffer#SendParagraph()<cr>
+	nnoremap <buffer> <del> :call wwws#buffer#Close()<del>
 endif

--- a/ftplugin/wwws.vim
+++ b/ftplugin/wwws.vim
@@ -38,4 +38,5 @@ endif
 
 if g:wwws_create_maps
     nnoremap <buffer> <cr> :call wwws#buffer#SendParagraph()<cr>
+    nnoremap <buffer> <del> :call wwws#buffer#Close()<del>
 endif

--- a/plugin/wwws.vim
+++ b/plugin/wwws.vim
@@ -2,7 +2,7 @@
 " Description: Main entry point for the plugin: sets up settings, etc.
 
 if exists('g:loaded_wildwildws')
-    finish
+	finish
 endif
 let g:loaded_wildwildws = 1
 

--- a/syntax/wwws.vim
+++ b/syntax/wwws.vim
@@ -4,7 +4,7 @@
 " Latest Revision: 24 April 2018
 
 if exists('b:current_syntax')
-  finish
+	finish
 endif
 
 " no syntax is better than a wrong syntax

--- a/syntax/wwws.vim
+++ b/syntax/wwws.vim
@@ -7,9 +7,7 @@ if exists('b:current_syntax')
   finish
 endif
 
-" just highlight like javascript for now
-runtime! syntax/javascript.vim
+" no syntax is better than a wrong syntax
 
 let b:current_syntax = 'wwws'
-
 


### PR DESCRIPTION
1. Wraps a few methods and `v:t_job` around a `has('nvim')` clause to make it work on latest neovim
2. Define a clearer default value if not websocket PID is found
3. Wraps `wwws#conn#Send(...)` around a function parametrized against a motion, so it's effortless to create new functions
4. I've added `wwws#buffer#SendLine()`, `wwws#buffer#SendHeadless()` and their `Delete` counterpart, which clears the buffer and stores it inside the unnamed register
5. Add extra mappings for the new functions by default.
6. All files are formatted with vim indent for consistency.

Tested:
NeoVim nightly v0.12
Vim latest v9.1